### PR TITLE
Minor CLI refactor

### DIFF
--- a/fastapi/__main__.py
+++ b/fastapi/__main__.py
@@ -1,3 +1,4 @@
 from fastapi.cli import main
 
-main()
+if __name__ == "__main__":
+    main()

--- a/fastapi/cli.py
+++ b/fastapi/cli.py
@@ -1,8 +1,11 @@
+from typing import Callable, Optional
+
+cli_main: Optional[Callable[[], None]]
+
 try:
     from fastapi_cli.cli import main as cli_main
-
 except ImportError:  # pragma: no cover
-    cli_main = None  # type: ignore
+    cli_main = None
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- annotate optional CLI entry point
- avoid side effects when importing `fastapi.__main__`

## Testing
- `ruff check fastapi/cli.py`
- `ruff check fastapi/__main__.py`
- `ruff check fastapi`
- `ruff check .`
- `ruff format fastapi/cli.py fastapi/__main__.py --check`
- `pytest -q tests/test_additional_properties.py::test_additional_properties` *(fails: ModuleNotFoundError: No module named 'httpx')*